### PR TITLE
'tag' and 'time' 

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ MysqlOutput needs MySQL server's host/port/database/username/password, and INSER
       table accesslog
       # 'columns' names order must be same with 'key_names'
       columns status,bytes,vhost,path,rhost,agent,referer
+      tag_column tag   # optional
+      time_column time # optional
       flush_intervals 5s
     </match>
 
@@ -46,6 +48,8 @@ Or, insert json into single column.
       username root
       table accesslog
       columns jsondata
+      tag_column tag   # optional
+      time_column time # optional
       format json
       flush_intervals 5s
     </match>
@@ -55,7 +59,6 @@ Now, out_mysql cannnot handle tag/time as output data.
 ## TODO
 
 * implement 'tag_mapped'
-* implement 'time' and 'tag' in key_names
 
 ## Copyright
 

--- a/test/plugin/test_out_mysql.rb
+++ b/test/plugin/test_out_mysql.rb
@@ -66,6 +66,83 @@ sql INSERT INTO baz (col1,col2,col3,col4) VALUES (?,?,?,?)
     }
   end
 
+  def test_configure_with_tag
+    d = create_driver %[
+host database.local
+database foo
+username bar
+table baz
+columns jsondata
+tag_column tag
+format json
+    ]
+    assert_equal 'INSERT INTO baz (jsondata,tag) VALUES (?,?)', d.instance.sql
+
+    d = create_driver %[
+host database.local
+database foo
+username bar
+password mogera
+key_names field1,field2,field3
+table baz
+columns col1,col2,col3
+tag_column tag
+    ]
+    assert_equal 'INSERT INTO baz (col1,col2,col3,tag) VALUES (?,?,?,?)', d.instance.sql
+  end
+
+  def test_configure_with_time
+    d = create_driver %[
+host database.local
+database foo
+username bar
+table baz
+columns jsondata
+time_column time
+format json
+    ]
+    assert_equal 'INSERT INTO baz (jsondata,time) VALUES (?,?)', d.instance.sql
+
+    d = create_driver %[
+host database.local
+database foo
+username bar
+password mogera
+key_names field1,field2,field3
+table baz
+columns col1,col2,col3
+time_column time
+    ]
+    assert_equal 'INSERT INTO baz (col1,col2,col3,time) VALUES (?,?,?,?)', d.instance.sql
+  end
+
+  def test_configure_with_tag_and_time
+    d = create_driver %[
+host database.local
+database foo
+username bar
+table baz
+columns jsondata
+tag_column tag
+time_column time
+format json
+    ]
+    assert_equal 'INSERT INTO baz (jsondata,tag,time) VALUES (?,?,?)', d.instance.sql
+
+    d = create_driver %[
+host database.local
+database foo
+username bar
+password mogera
+key_names field1,field2,field3
+table baz
+columns col1,col2,col3
+tag_column tag
+time_column time
+    ]
+    assert_equal 'INSERT INTO baz (col1,col2,col3,tag,time) VALUES (?,?,?,?,?)', d.instance.sql
+  end
+
   def test_format
     d = create_driver
 


### PR DESCRIPTION
tag_column と time_column オプションで tag と time のカラムを指定出来るようにしてみました。
time と tag を上手に表現するのが難しそうだったので、sql文を書く場合は指定出来ないままです。
