### PR TITLE
support key_names including spaces

### DIFF
--- a/lib/fluent/plugin/out_mysql.rb
+++ b/lib/fluent/plugin/out_mysql.rb
@@ -34,7 +34,7 @@ class Fluent::MysqlOutput < Fluent::BufferedOutput
     when 'json'
       @format_proc = Proc.new{|tag, time, record| record.to_json}
     when 'jsonpath'
-      @key_names = @key_names.split(',')
+      @key_names = @key_names.split(/\s*,\s*/)
       @format_proc = Proc.new do |tag, time, record|
         json = record.to_json
         @key_names.map do |k|
@@ -65,7 +65,7 @@ class Fluent::MysqlOutput < Fluent::BufferedOutput
       end
     else # columns
       raise Fluent::ConfigError, "table missing" unless @table
-      @columns = @columns.split(',')
+      @columns = @columns.split(/\s*,\s*/)
       cols = @columns.join(',')
       placeholders = if @format == 'json'
                        '?'

--- a/test/plugin/test_out_mysql.rb
+++ b/test/plugin/test_out_mysql.rb
@@ -52,8 +52,20 @@ username bar
 password mogera
 key_names field1,field2,field3
 table baz
-columns col1,col2,col3
+columns col1, col2 ,col3
     ]
+    assert_equal ['field1', 'field2', 'field3'], d.instance.key_names
+    assert_equal 'INSERT INTO baz (col1,col2,col3) VALUES (?,?,?)', d.instance.sql
+    d = create_driver %[
+host database.local
+database foo
+username bar
+password mogera
+key_names field1 ,field2, field3
+table baz
+columns col1, col2 ,col3
+    ]
+    assert_equal ['field1', 'field2', 'field3'], d.instance.key_names
     assert_equal 'INSERT INTO baz (col1,col2,col3) VALUES (?,?,?)', d.instance.sql
 
     assert_raise(Fluent::ConfigError) {
@@ -66,6 +78,8 @@ key_names field1,field2,field3
 sql INSERT INTO baz (col1,col2,col3,col4) VALUES (?,?,?,?)
       ]
     }
+
+
   end
 
   def test_format


### PR DESCRIPTION
When key_names includes space like `name, value, attr`, fail to parse key names.
