### PR TITLE
Add unit-test gem as development dependency

### DIFF
--- a/fluent-plugin-mysql.gemspec
+++ b/fluent-plugin-mysql.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "mysql2-cs-bind"
   gem.add_runtime_dependency "jsonpath"
   gem.add_development_dependency "rake"
+  gem.add_development_dependency "test-unit"
 end


### PR DESCRIPTION
When I run `rake test`, I receive 
```fluent-plugin-mysql/test/helper.rb:10:in `require': cannot load such file -- test/unit (LoadError)```

Adding `unit-test` as a development dependency fixes this issue.