### PR TITLE
Do not use nonstandard timezone in tests

### DIFF
--- a/test/plugin/test_out_mysql.rb
+++ b/test/plugin/test_out_mysql.rb
@@ -137,7 +137,7 @@ sql INSERT INTO baz (coltime,coltag,col1,col2,col3,col4) VALUES (?,?,?,?,?,?)
     ]
     assert_equal 'INSERT INTO baz (coltime,coltag,col1,col2,col3,col4) VALUES (?,?,?,?,?,?)', d.instance.sql
 
-    time = Time.parse('2012-12-17 09:23:45 JST').to_i # JST(+0900)
+    time = Time.parse('2012-12-17 09:23:45 +0900').to_i # JST(+0900)
     record = {'field1'=>'value1','field2'=>'value2','field3'=>'value3','field4'=>'value4'}
     d.emit(record, time)
     d.expect_format ['test', time, ['20121217-002345','test','value1','value2','value3','value4']].to_msgpack
@@ -162,7 +162,7 @@ format json
     ]
     assert_equal 'INSERT INTO accesslog (jsondata) VALUES (?)', d.instance.sql
 
-    time = Time.parse('2012-12-17 09:23:45 JST').to_i # JST(+0900)
+    time = Time.parse('2012-12-17 09:23:45 +0900').to_i # JST(+0900)
     record = {'field1'=>'value1'}
     d.emit(record, time)
     # Ruby 1.9.3 Hash saves its key order, so this code is OK.


### PR DESCRIPTION
Two tests with JST timezone fail on my machine.
This happens because 
 - JST is not a standard [RFC0822](https://www.ietf.org/rfc/rfc0822.txt) timezone
 - my system timezone is EST

According to `Time.parse` documentation:
> (...) this method only understands the time zone abbreviations described in RFC 822 and the system time zone, in the order named.

Therefore, those tests will only pass on a system with a timezone set to JST.