### PR TITLE
added options for sslca to perform client mysql encryption

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -13,6 +13,10 @@ module Fluent
                  :desc => "Database user."
     config_param :password, :string, default: '', secret: true,
                  :desc => "Database password."
+    config_param :sslca, :string, default: '',
+                 :desc => "Filename for SSL bundle CA cert."
+                 :desc => "Path to SSL bundle CA cert."
+    config_param :sslcapath, :string, default: '',
 
     config_param :column_names, :string,
                  :desc => "Bulk insert column."
@@ -99,6 +103,8 @@ DESC
           username: @username,
           password: @password,
           database: @database,
+          sslca: @sslca,
+          sslcapath: @sslcapath,
           flags: Mysql2::Client::MULTI_STATEMENTS
         )
     end
@@ -144,3 +150,4 @@ DESC
     end
   end
 end
+


### PR DESCRIPTION
Added options from mysql2 library to establish ssl encryption by defining sslca options.

I'm a noob to github.  Please forgive my multiple pull requests.