### PR TITLE
Supported time format with timezone considered.

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ http://docs.fluentd.org/articles/formatter-plugin-overview
   password hogehoge
 
   include_time_key yes
-  timezone Asia/Tokyo
+  timezone +00
   time_format %Y-%m-%d %H:%M:%S
   time_key created_at
 
@@ -207,7 +207,7 @@ http://docs.fluentd.org/articles/formatter-plugin-overview
 </match>
 ```
 
-Assume following input is coming:
+Assume following input is coming(fluentd server is using JST +09 timezone):
 
 ```js
 2014-01-03 21:35:15+09:00: mysql.input: {"user":"toyama","dummy":"hogehoge"}
@@ -215,7 +215,7 @@ Assume following input is coming:
 2014-01-03 21:35:27+09:00: mysql.input: {"user":"toyama3","dummy":"hogehoge"}
 ```
 
-then `created_at` column is set from time attribute in a fluentd packet with timezone converted:
+then `created_at` column is set from time attribute in a fluentd packet with timezone converted to +00 UTC:
 
 ```sql
 +-----+-----------+---------------------+

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -3,6 +3,8 @@ module Fluent
   class Fluent::MysqlBulkOutput < Fluent::BufferedOutput
     Fluent::Plugin.register_output('mysql_bulk', self)
 
+    include Fluent::SetTimeKeyMixin
+
     config_param :host, :string, default: '127.0.0.1',
                  :desc => "Database host."
     config_param :port, :integer, default: 3306,


### PR DESCRIPTION
I'd like to convert the timezone of time in a fluentd packet because I manage JST application servers(or fluentd server) which connect UTC mysql.
(I think this is not so rare case.)
I confirmed this pull request achieves the timezone considered time formatting without breaking the `${time}` behavior.

Ex): timezone sensitive case

```
include_time_key yes
utc
time_format %Y-%m-%d %H:%M:%S
time_key created_at
column_names user_id,created_at
key_names user_id,created_at
```

Ex): conventional easy to use case

```
column_names user_id,created_at
key_names user_id,${time}
```