### PR TITLE
Allow having spaces in column and key names

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -65,8 +65,8 @@ DESC
         @on_duplicate_key_update_sql += updates.join(',')
       end
 
-      @column_names = @column_names.split(',')
-      @key_names = @key_names.nil? ? @column_names : @key_names.split(',')
+      @column_names = @column_names.split(',').collect(&:strip)
+      @key_names = @key_names.nil? ? @column_names : @key_names.split(',').collect(&:strip)
       @json_key_names = @json_key_names.split(',') if @json_key_names
     end
 

--- a/test/plugin/test_out_mysql_bulk.rb
+++ b/test/plugin/test_out_mysql_bulk.rb
@@ -184,4 +184,29 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     assert_equal ['request_headers','params'], d.instance.json_key_names
     assert_nil d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
   end
+
+  def test_spaces_in_columns
+    d = create_driver %[
+      database test_app_development
+      username root
+      password hogehoge
+      column_names id, user_name, created_at, updated_at
+      table users
+    ]
+
+    assert_equal ['id','user_name','created_at','updated_at'], d.instance.key_names
+    assert_equal ['id','user_name','created_at','updated_at'], d.instance.column_names
+
+    d = create_driver %[
+      database test_app_development
+      username root
+      password hogehoge
+      key_names id, user_name, created_at, updated_at
+      column_names id, user_name, created_at, updated_at
+      table users
+    ]
+
+    assert_equal ['id','user_name','created_at','updated_at'], d.instance.key_names
+    assert_equal ['id','user_name','created_at','updated_at'], d.instance.column_names
+  end
 end


### PR DESCRIPTION
Without this any field with a space after the comma ends up blank in mysql.