### PR TITLE
Log table name alongside insert size in write method

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -115,7 +115,7 @@ DESC
       sql = "INSERT INTO #{@table} (#{@column_names.join(',')}) VALUES #{values.join(',')}"
       sql += @on_duplicate_key_update_sql if @on_duplicate_key_update
 
-      log.info "bulk insert values size => #{values.size}"
+      log.info "bulk insert values size (table: #{@table}) => #{values.size}"
       @handler.xquery(sql)
       @handler.close
     end


### PR DESCRIPTION
When using this plugin to output events from multiple tags to different MySQL tables, the log message issued on each chunk write is ambiguous as to which table the chunk is being written to. The change is to log the table name in addition to the number of rows in the INSERT.

