### PR TITLE
Migrate to v0.14 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,12 @@
 language: ruby
 
 rvm:
-  - 2.0.0
   - 2.1
   - 2.2.3
   - 2.3.0
 
 gemfile:
   - Gemfile
-
-matrix:
-  exclude:
-    - rvm: 2.0.0
-      gemfile: Gemfile
 
 before_install:
   - gem update bundler

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ then `created_at` column is set from time attribute in a fluentd packet with tim
 
 ## Configuration Example(bulk insert with tag placeholder for table name)
 
+This description is for v0.14.X users.
+
 ```
 <match mysql.input>
   @type mysql_bulk
@@ -272,6 +274,8 @@ mysql> select * from users_mysql_input;
 ```
 
 ## Configuration Example(bulk insert with time format placeholder for table name)
+
+This description is for v0.14.X users.
 
 ```
 <match mysql.input>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ fluent-plugin-mysql-bulk merged this repository.
 
 [mysql plugin](README_mysql.md) is deprecated. You should use mysql_bulk.
 
+v0.1.5 only supports fluentd-0.12.X and v0.2.0 only supports fluentd-0.14.X.
+
 ## Parameters
 
 param|value

--- a/README.md
+++ b/README.md
@@ -228,6 +228,88 @@ then `created_at` column is set from time attribute in a fluentd packet with tim
 +-----+-----------+---------------------+
 ```
 
+## Configuration Example(bulk insert with tag placeholder for table name)
+
+```
+<match mysql.input>
+  @type mysql_bulk
+  host localhost
+  database test_app_development
+  username root
+  password hogehoge
+  column_names id,user_name,created_at
+  key_names id,user,${time}
+  table users_${tag}
+  <buffer tag>
+    @type memory
+    flush_interval 60s
+  </buffer>
+</match>
+```
+
+Assume following input is coming:
+
+```js
+2016-09-26 18:42:13+09:00: mysql.input: {"user":"toyama","dummy":"hogehoge"}
+2016-09-26 18:42:16+09:00: mysql.input: {"user":"toyama2","dummy":"hogehoge"}
+2016-09-26 18:42:19+09:00: mysql.input: {"user":"toyama3","dummy":"hogehoge"}
+```
+
+then `created_at` column is set from time attribute in a fluentd packet:
+
+```sql
+mysql> select * from users_mysql_input;
++----+-----------+---------------------+
+| id | user_name | created_at          |
++----+-----------+---------------------+
+|  1 | toyama    | 2016-09-26 18:42:13 |
+|  2 | toyama2   | 2016-09-26 18:42:16 |
+|  3 | toyama3   | 2016-09-26 18:42:19 |
++----+-----------+---------------------+
+3 rows in set (0.00 sec)
+```
+
+## Configuration Example(bulk insert with time format placeholder for table name)
+
+```
+<match mysql.input>
+  @type mysql_bulk
+  host localhost
+  database test_app_development
+  username root
+  password hogehoge
+  column_names id,user_name,created_at
+  key_names id,user,${time}
+  table users_%Y%m%d
+  <buffer time>
+    @type memory
+    timekey 60s
+    timekey_wait 60s
+  </buffer>
+</match>
+```
+
+Assume following input is coming:
+
+```js
+2016-09-26 18:37:06+09:00: mysql.input: {"user":"toyama","dummy":"hogehoge"}
+2016-09-26 18:37:08+09:00: mysql.input: {"user":"toyama2","dummy":"hogehoge"}
+2016-09-26 18:37:11+09:00: mysql.input: {"user":"toyama3","dummy":"hogehoge"}
+```
+
+then `created_at` column is set from time attribute in a fluentd packet:
+
+```sql
+mysql> select * from users_20160926;
++----+-----------+---------------------+
+| id | user_name | created_at          |
++----+-----------+---------------------+
+|  1 | toyama    | 2016-09-26 18:37:06 |
+|  2 | toyama2   | 2016-09-26 18:37:08 |
+|  3 | toyama3   | 2016-09-26 18:37:11 |
++----+-----------+---------------------+
+3 rows in set (0.00 sec)
+```
 
 ## spec
 

--- a/fluent-plugin-mysql.gemspec
+++ b/fluent-plugin-mysql.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "fluentd", '~> 0.12.0'
+  gem.add_runtime_dependency "fluentd", ['>= 0.14.8', '< 2']
   gem.add_runtime_dependency "mysql2-cs-bind"
   gem.add_runtime_dependency "jsonpath"
   gem.add_development_dependency "rake"

--- a/fluent-plugin-mysql.gemspec
+++ b/fluent-plugin-mysql.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "jsonpath"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "test-unit"
+  gem.add_development_dependency "timecop", "~> 0.8.0"
 end

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -70,7 +70,11 @@ DESC
 
     def start
       super
-      result = client.xquery("SHOW COLUMNS FROM #{@table}")
+      check_table_schema
+    end
+
+    def check_table_schema(database: @database, table: @table)
+      result = client(database).xquery("SHOW COLUMNS FROM #{table}")
       @max_lengths = []
       @column_names.each do |column|
         info = result.select { |x| x['Field'] == column }.first

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -1,6 +1,8 @@
 # -*- encoding : utf-8 -*-
-module Fluent
-  class Fluent::MysqlBulkOutput < Fluent::BufferedOutput
+require 'fluent/plugin/output'
+
+module Fluent::Plugin
+  class MysqlBulkOutput < Output
     Fluent::Plugin.register_output('mysql_bulk', self)
 
     include Fluent::SetTimeKeyMixin

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -5,7 +5,7 @@ module Fluent::Plugin
   class MysqlBulkOutput < Output
     Fluent::Plugin.register_output('mysql_bulk', self)
 
-    include Fluent::SetTimeKeyMixin
+    helpers :compat_parameters, :inject
 
     config_param :host, :string, default: '127.0.0.1',
                  :desc => "Database host."
@@ -47,6 +47,7 @@ DESC
     end
 
     def configure(conf)
+      compat_parameters_convert(conf, :inject)
       super
 
       if @column_names.nil?
@@ -93,6 +94,7 @@ DESC
     end
 
     def format(tag, time, record)
+      record = inject_values_to_record(tag, time, record)
       [tag, time, format_proc.call(tag, time, record)].to_msgpack
     end
 

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -41,11 +41,6 @@ DESC
       require 'mysql2-cs-bind'
     end
 
-    # Define `log` method for v0.10.42 or earlier
-    unless method_defined?(:log)
-      define_method("log") { $log }
-    end
-
     def configure(conf)
       compat_parameters_convert(conf, :inject)
       super

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -8,31 +8,31 @@ module Fluent::Plugin
     helpers :compat_parameters, :inject
 
     config_param :host, :string, default: '127.0.0.1',
-                 :desc => "Database host."
+                 desc: "Database host."
     config_param :port, :integer, default: 3306,
-                 :desc => "Database port."
+                 desc: "Database port."
     config_param :database, :string,
-                 :desc => "Database name."
+                 desc: "Database name."
     config_param :username, :string,
-                 :desc => "Database user."
+                 desc: "Database user."
     config_param :password, :string, default: '', secret: true,
-                 :desc => "Database password."
+                 desc: "Database password."
 
     config_param :column_names, :string,
-                 :desc => "Bulk insert column."
+                 desc: "Bulk insert column."
     config_param :key_names, :string, default: nil,
-                 :desc => <<-DESC
+                 desc: <<-DESC
 Value key names, ${time} is placeholder Time.at(time).strftime("%Y-%m-%d %H:%M:%S").
 DESC
     config_param :json_key_names, :string, default: nil,
-                  :desc => "Key names which store data as json"
+                  desc: "Key names which store data as json"
     config_param :table, :string,
-                 :desc => "Bulk insert table."
+                 desc: "Bulk insert table."
 
     config_param :on_duplicate_key_update, :bool, default: false,
-                 :desc => "On duplicate key update enable."
+                 desc: "On duplicate key update enable."
     config_param :on_duplicate_update_keys, :string, default: nil,
-                 :desc => "On duplicate key update column, comma separator."
+                 desc: "On duplicate key update column, comma separator."
 
     attr_accessor :handler
 

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -111,6 +111,7 @@ DESC
     def write(chunk)
       database = extract_placeholders(@database, chunk.metadata)
       table = extract_placeholders(@table, chunk.metadata)
+      check_table_schema(database: database, table: table)
       @handler = client(database)
       values = []
       values_template = "(#{ @column_names.map { |key| '?' }.join(',') })"

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -97,6 +97,10 @@ DESC
       [tag, time, record].to_msgpack
     end
 
+    def formatted_to_msgpack_binary
+      true
+    end
+
     def client(database)
       Mysql2::Client.new(
           host: @host,

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -108,9 +108,14 @@ DESC
         )
     end
 
+    def expand_placeholders(metadata)
+      database = extract_placeholders(@database, metadata).gsub('.', '_')
+      table = extract_placeholders(@table, metadata).gsub('.', '_')
+      return database, table
+    end
+
     def write(chunk)
-      database = extract_placeholders(@database, chunk.metadata)
-      table = extract_placeholders(@table, chunk.metadata).gsub('.', '_')
+      database, table = expand_placeholders(chunk.metadata)
       max_lengths = check_table_schema(database: database, table: table)
       @handler = client(database)
       values = []

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -70,7 +70,6 @@ DESC
 
     def start
       super
-      check_table_schema
     end
 
     def check_table_schema(database: @database, table: @table)

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -42,7 +42,7 @@ DESC
     end
 
     def configure(conf)
-      compat_parameters_convert(conf, :inject)
+      compat_parameters_convert(conf, :buffer, :inject)
       super
 
       if @column_names.nil?

--- a/test/plugin/test_out_mysql_bulk.rb
+++ b/test/plugin/test_out_mysql_bulk.rb
@@ -1,13 +1,14 @@
 require 'helper'
 require 'mysql2-cs-bind'
+require 'fluent/test/driver/output'
 
 class MysqlBulkOutputTest < Test::Unit::TestCase
   def setup
     Fluent::Test.setup
   end
 
-  def create_driver(conf = CONFIG, tag = 'test')
-    d = Fluent::Test::BufferedOutputTestDriver.new(Fluent::MysqlBulkOutput, tag).configure(conf)
+  def create_driver(conf = CONFIG)
+    d = Fluent::Test::Driver::Output.new(Fluent::Plugin::MysqlBulkOutput).configure(conf)
     d.instance.instance_eval {
       def client
         obj = Object.new

--- a/test/plugin/test_out_mysql_bulk.rb
+++ b/test/plugin/test_out_mysql_bulk.rb
@@ -24,7 +24,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
 
   def test_configure_error
     assert_raise(Fluent::ConfigError) do
-      d = create_driver %[
+      create_driver %[
         host localhost
         database test_app_development
         username root
@@ -37,7 +37,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     end
 
     assert_raise(Fluent::ConfigError) do
-      d = create_driver %[
+      create_driver %[
         host localhost
         database test_app_development
         username root
@@ -50,7 +50,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     end
 
     assert_raise(Fluent::ConfigError) do
-      d = create_driver %[
+      create_driver %[
         host localhost
         username root
         password hogehoge
@@ -66,7 +66,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
   def test_configure
     # not define format(default csv)
     assert_nothing_raised(Fluent::ConfigError) do
-      d = create_driver %[
+      create_driver %[
         host localhost
         database test_app_development
         username root
@@ -80,7 +80,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     end
 
     assert_nothing_raised(Fluent::ConfigError) do
-      d = create_driver %[
+      create_driver %[
         database test_app_development
         username root
         password hogehoge
@@ -90,7 +90,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     end
 
     assert_nothing_raised(Fluent::ConfigError) do
-      d = create_driver %[
+      create_driver %[
         database test_app_development
         username root
         password hogehoge
@@ -102,7 +102,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     end
 
     assert_nothing_raised(Fluent::ConfigError) do
-      d = create_driver %[
+      create_driver %[
         database test_app_development
         username root
         password hogehoge
@@ -115,7 +115,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     end
 
     assert_nothing_raised(Fluent::ConfigError) do
-      d = create_driver %[
+      create_driver %[
         database test_app_development
         username root
         password hogehoge


### PR DESCRIPTION
I've tested with the following conf:

```xml
<source>
  @type forward
</source>
<match mysql.input>
  @type mysql_bulk
  host localhost
  database test_app_development
  username root
  password ""
  column_names id,user_name,created_at,updated_at
  table users
  <buffer tag>
    @type memory
    flush_interval 10s
  </buffer>
</match>
```

Incoming json as follows:

```
$ echo '{"user_name": "test", "created_at": "2016-09-10", "updated_at": "2016-09-21"}' | bundle exec fluent-cat mysql.input
$ echo '{"user_name": "test2", "created_at": "2016-09-20", "updated_at": "2016-09-21"}' | bundle exec fluent-cat mysql.input
$ echo '{"user_name": "test3", "created_at": "2016-09-11", "updated_at": "2016-09-21"}' | bundle exec fluent-cat mysql.input
$ echo '{"user_name": "test4", "created_at": "2016-09-11", "updated_at": "2016-09-21"}' | bundle exec fluent-cat mysql.input
```

mysql_bulk working log is:

```log
$ bundle exec fluentd -c fluent-mysql.conf 
2016-09-21 13:19:54 +0900 [info]: reading config file path="fluent-mysql.conf"
2016-09-21 13:19:54 +0900 [info]: starting fluentd-0.14.6
2016-09-21 13:19:54 +0900 [info]: spawn command to main: /Users/hhatake/.rbenv/versions/2.3.0/bin/ruby -Eascii-8bit:ascii-8bit  -rbundler/setup /Users/hhatake/Github/fluent-plugin-mysql/vendor/bundle/ruby/2.3.0/bin/fluentd -c fluent-mysql.conf --under-supervisor
2016-09-21 13:19:55 +0900 [info]: reading config file path="fluent-mysql.conf"
2016-09-21 13:19:55 +0900 [info]: starting fluentd-0.14.6 without supervision
2016-09-21 13:19:55 +0900 [info]: gem 'fluentd' version '0.14.6'
2016-09-21 13:19:55 +0900 [info]: gem 'fluent-plugin-mysql' version '0.1.4'
2016-09-21 13:19:55 +0900 [info]: adding match pattern="mysql.input" type="mysql_bulk"
2016-09-21 13:19:55 +0900 [info]: adding source type="forward"
2016-09-21 13:19:55 +0900 [info]: using configuration file: <ROOT>
  <source>
    @type forward
  </source>
  <match mysql.input>
    @type mysql_bulk
    host "localhost"
    database "test_app_development"
    username "root"
    password xxxxxx
    column_names "id,user_name,created_at,updated_at"
    table "users"
    <buffer tag>
      @type "memory"
      flush_interval 10s
    </buffer>
  </match>
</ROOT>
2016-09-21 13:19:55 +0900 [info]: listening fluent socket on 0.0.0.0:24224
2016-09-21 13:20:08 +0900 [info]: bulk insert values size (table: users) => 1
2016-09-21 13:20:54 +0900 [info]: bulk insert values size (table: users) => 1
2016-09-21 13:21:32 +0900 [info]: bulk insert values size (table: users) => 2
```

MySQL database schema is like this:

```log
mysql> desc users;
+------------+--------------+------+-----+---------+----------------+
| Field      | Type         | Null | Key | Default | Extra          |
+------------+--------------+------+-----+---------+----------------+
| id         | int(11)      | NO   | PRI | NULL    | auto_increment |
| user_name  | varchar(255) | YES  |     | NULL    |                |
| created_at | datetime     | NO   |     | NULL    |                |
| updated_at | datetime     | NO   |     | NULL    |                |
+------------+--------------+------+-----+---------+----------------+
4 rows in set (0.00 sec)
```

MySQL stores these records as follows:

```log
mysql> select * from users;
+----+-----------+---------------------+---------------------+
| id | user_name | created_at          | updated_at          |
+----+-----------+---------------------+---------------------+
|  1 | test      | 2016-09-10 00:00:00 | 2016-09-21 00:00:00 |
|  2 | test2     | 2016-09-20 00:00:00 | 2016-09-21 00:00:00 |
|  3 | test3     | 2016-09-11 00:00:00 | 2016-09-21 00:00:00 |
|  4 | test4     | 2016-09-11 00:00:00 | 2016-09-21 00:00:00 |
+----+-----------+---------------------+---------------------+
4 rows in set (0.00 sec)
```