### PR TITLE
"LICENSE" link is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,4 +251,4 @@ divide bulk insert(exsample 1000 per)
 
 ## Copyright
 
-Copyright (c) 2016 Hiroshi Toyama. See [LICENSE](LICENSE) for details.
+Copyright (c) 2016 Hiroshi Toyama. See [LICENSE](LICENSE.txt) for details.


### PR DESCRIPTION
The link destination should be `LICENSE.txt`.