### PR TITLE
Stop choking when trying to put integer to a varchar or char column

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -165,7 +165,7 @@ DESC
             if max_lengths[i].nil? || record[key].nil?
               value = record[key]
             else
-              value = record[key].slice(0, max_lengths[i])
+              value = record[key].to_s.slice(0, max_lengths[i])
             end
 
             if @json_key_names && @json_key_names.include?(key)


### PR DESCRIPTION
When a column is defined with varchar or char types, inserting an integer value to the column causes following error:

```
failed to configure/start sub output mysql: undefined method `split' for nil:NilClass
```

This is because the fluent-plugin-mysql tries to cut the value to the maximum length that is defined in the schema, assuming the value is of string type.
This patch fixes the problem by type-casting the value to a string before splitting.
