### PR TITLE
Escape column names in the INSERT statement

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -145,7 +145,7 @@ DESC
         data = format_proc.call(tag, time, data, max_lengths)
         values << Mysql2::Client.pseudo_bind(values_template, data)
       end
-      sql = "INSERT INTO #{table} (#{@column_names.join(',')}) VALUES #{values.join(',')}"
+      sql = "INSERT INTO #{table} (#{@column_names.map{|x| "`#{x.to_s.gsub('`', '``')}`"}.join(',')}) VALUES #{values.join(',')}"
       sql += @on_duplicate_key_update_sql if @on_duplicate_key_update
 
       log.info "bulk insert values size (table: #{table}) => #{values.size}"


### PR DESCRIPTION
The fluent-plugin-mysql does not escape or quote the column names defined in the td-agent configuration. When there is a column that matches one of MySQL reserved words, td-agent fails to flush the buffer with following message:

```
error_class=Mysql2::Error error="You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near
```

This patch fixes this problem by quoting the column names when building the INSERT SQL statement. The escape algorithm is taken from ActiveRecord  (as it appears in `quote_column_name` function on `activerecord/lib/active_record/connection_adapters/mysql/quoting.rb` ), so I hope this is the right way to do it.