### PR TITLE
Fix: "no slice method" error on Fixnum and Float types

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -165,7 +165,7 @@ DESC
             if max_lengths[i].nil? || record[key].nil?
               value = record[key]
             else
-              value = record[key].slice(0, max_lengths[i])
+              value = record[key].to_s.slice(0, max_lengths[i])
             end
 
             if @json_key_names && @json_key_names.include?(key)


### PR DESCRIPTION
The plugin doesn't work with records containing `Float` or `Fixnum` values.

Always convert values to string for slicing according to column's max length
since MySQL will automatically cast back strings into numeric columns types
anyway.