### PR TITLE
add unixtimestamp_key_names

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -28,6 +28,9 @@ DESC
     config_param :table, :string,
                  desc: "Bulk insert table."
 
+    config_param :unixtimestamp_key_names, :string, default: nil,
+                 desc: "Key names which store data as datetime from unix time stamp"
+
     config_param :on_duplicate_key_update, :bool, default: false,
                  desc: "On duplicate key update enable."
     config_param :on_duplicate_update_keys, :string, default: nil,
@@ -82,6 +85,7 @@ DESC
       @column_names = @column_names.split(',').collect(&:strip)
       @key_names = @key_names.nil? ? @column_names : @key_names.split(',').collect(&:strip)
       @json_key_names = @json_key_names.split(',') if @json_key_names
+      @unixtimestamp_key_names = @unixtimestamp_key_names.split(',') if @unixtimestamp_key_names
     end
 
     def check_table_schema(database: @database, table: @table)
@@ -161,6 +165,10 @@ DESC
 
             if @json_key_names && @json_key_names.include?(key)
               value = value.to_json
+            end
+
+            if @unixtimestamp_key_names && @unixtimestamp_key_names.include?(key)
+              value = Time.at(value).strftime('%Y-%m-%d %H:%M:%S')
             end
           end
           values << value

--- a/test/plugin/test_out_mysql_bulk.rb
+++ b/test/plugin/test_out_mysql_bulk.rb
@@ -266,6 +266,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.key_names
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.column_names
     assert_equal nil, d.instance.json_key_names
+    assert_equal nil, d.instance.unixtimestamp_key_names
     assert_equal " ON DUPLICATE KEY UPDATE user_name = VALUES(user_name),updated_at = VALUES(updated_at)", d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
 
     d = create_driver %[
@@ -279,6 +280,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.key_names
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.column_names
     assert_equal nil, d.instance.json_key_names
+    assert_equal nil, d.instance.unixtimestamp_key_names
     assert_nil d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
 
     d = create_driver %[
@@ -293,6 +295,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.key_names
     assert_equal ['id','user','created_date','updated_date'], d.instance.column_names
     assert_equal nil, d.instance.json_key_names
+    assert_equal nil, d.instance.unixtimestamp_key_names
     assert_nil d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
 
     d = create_driver %[
@@ -301,6 +304,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
       password hogehoge
       key_names id,url,request_headers,params,created_at,updated_at
       column_names id,url,request_headers_json,params_json,created_date,updated_date
+      unixtimestamp_key_names created_at,updated_at
       json_key_names request_headers,params
       table access
     ]
@@ -308,6 +312,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     assert_equal ['id','url','request_headers','params','created_at','updated_at'], d.instance.key_names
     assert_equal ['id','url','request_headers_json','params_json','created_date','updated_date'], d.instance.column_names
     assert_equal ['request_headers','params'], d.instance.json_key_names
+    assert_equal ['created_at', 'updated_at'], d.instance.unixtimestamp_key_names
     assert_nil d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
 
     d = create_driver %[
@@ -324,6 +329,7 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     assert_equal ['id','user_name','login_count','created_at','updated_at'], d.instance.key_names
     assert_equal ['id','user_name','login_count','created_at','updated_at'], d.instance.column_names
     assert_equal nil, d.instance.json_key_names
+    assert_equal nil, d.instance.unixtimestamp_key_names
     assert_equal " ON DUPLICATE KEY UPDATE login_count = `login_count` + 1,updated_at = VALUES(updated_at)", d.instance.instance_variable_get(:@on_duplicate_key_update_sql)
   end
 


### PR DESCRIPTION
Because unixtimestamp is an integer, it can not be inserted into MySQL datetime type column.
When unixtimestamp is converted to datetime, it can be inserted into MySQL datetime type.