### PR TITLE
use oj to avoid encoding errors

### DIFF
--- a/fluent-plugin-mysql.gemspec
+++ b/fluent-plugin-mysql.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency "fluentd", ['>= 0.14.8', '< 2']
   gem.add_runtime_dependency "mysql2-cs-bind"
   gem.add_runtime_dependency "jsonpath"
+  gem.add_runtime_dependency "oj"
   gem.add_development_dependency "rake"
   gem.add_development_dependency "test-unit"
   gem.add_development_dependency "timecop", "~> 0.8.0"

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -1,4 +1,5 @@
 require 'fluent/plugin/output'
+require 'oj'
 
 module Fluent::Plugin
   class MysqlBulkOutput < Output
@@ -186,7 +187,7 @@ DESC
             end
 
             if @json_key_names && @json_key_names.include?(key)
-              value = value.to_json
+              value = Oj.dump(value)
             end
 
             if @unixtimestamp_key_names && @unixtimestamp_key_names.include?(key)


### PR DESCRIPTION
If you use standard library json, encoding errors may occur.
oj does not have that kind of problem, and it is fast.

refs https://github.com/tagomoris/fluent-plugin-mysql/issues/46