### PR TITLE
Add support for setting the encoding and collation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ sslca|path to ca cert(default: nil)
 sslcapath|path to ca certs(default: nil)
 sslcipher|ssl cipher(default: nil)
 sslverify|verify server certificate(default: nil)
+encoding|encoding(default: nil)
+collation|collation(default: nil)
 column_names|bulk insert column (require)
 key_names|value key names, ${time} is placeholder Time.at(time).strftime("%Y-%m-%d %H:%M:%S") (default : column_names)
 json_key_names|Key names which store data as json, comma separator.
@@ -41,6 +43,8 @@ on_duplicate_update_keys|on duplicate key update column, comma separator
   database test_app_development
   username root
   password hogehoge
+  encoding utf8mb4
+  collation utf8mb4_unicode_ci
   column_names id,user_name,created_at,updated_at
   table users
   flush_interval 10s

--- a/lib/fluent/plugin/out_mysql.rb
+++ b/lib/fluent/plugin/out_mysql.rb
@@ -15,6 +15,8 @@ class Fluent::MysqlOutput < Fluent::BufferedOutput
   config_param :sslcapath, :string, :default => nil
   config_param :sslcipher, :string, :default => nil
   config_param :sslverify, :bool, :default => nil
+  config_param :encoding, :string, :default => nil
+  config_param :collation, :string, :default => nil
 
   config_param :key_names, :string, :default => nil # nil allowed for json format
   config_param :sql, :string, :default => nil
@@ -112,6 +114,8 @@ class Fluent::MysqlOutput < Fluent::BufferedOutput
         :sslcapath => @sslcapath,
         :sslcipher => @sslcipher,
         :sslverify => @sslverify,
+        :encoding => @encoding,
+        :collation => @collation,
         :flags => Mysql2::Client::MULTI_STATEMENTS,
       })
   end

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -28,6 +28,10 @@ module Fluent::Plugin
                          desc: "SSL cipher."
     config_param :sslverify, :bool, default: nil,
                              desc: "SSL Verify Server Certificate."
+    config_param :encoding, :string, default: nil,
+                         desc: "Connection encoding."
+    config_param :collation, :string, default: nil,
+                         desc: "Connection collation."
 
     config_param :column_names, :string,
                  desc: "Bulk insert column."
@@ -142,6 +146,8 @@ DESC
           sslcapath: @sslcapath,
           sslcipher: @sslcipher,
           sslverify: @sslverify,
+          encoding: @encoding,
+          collation: @collation,
           flags: Mysql2::Client::MULTI_STATEMENTS
         )
     end


### PR DESCRIPTION
Simple changes to allow the encoding and collation attributes for mysql2 to be set on the fluent plugin.

This is necessary to enable the writing of utf8mb4 data into mysql out of fluent, as otherwise the connection defaults to utf8 and the conversion fails. You need this to support emoji for example, or any other characters outside of 3 byte UTF-8.