### PR TITLE
Add transaction_isolation_level config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ unixtimestamp_key_names|Key names which store data as datetime from unix time st
 table|bulk insert table (require)
 on_duplicate_key_update|on duplicate key update enable (true:false)
 on_duplicate_update_keys|on duplicate key update column, comma separator
+transaction_isolation_level|set transaction isolation level(default: nil)
 
 ## Configuration Example(bulk insert)
 

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -51,6 +51,9 @@ DESC
     config_param :on_duplicate_update_custom_values, :string, default: nil,
                  desc: "On_duplicate_update_custom_values, comma separator. specify the column name is insert value, custom value is use ${sql conditions}"
 
+    config_param :transaction_isolation_level, :enum, list: [:read_uncommitted, :read_committed, :repeatable_read, :serializable], default: :repeatable_read,
+                 desc: "Set transaction isolation level."
+
     attr_accessor :handler
 
     def initialize
@@ -170,6 +173,7 @@ DESC
       sql += @on_duplicate_key_update_sql if @on_duplicate_key_update
 
       log.info "bulk insert values size (table: #{table}) => #{values.size}"
+      @handler.query("SET SESSION TRANSACTION ISOLATION LEVEL #{transaction_isolation_level}")
       @handler.xquery(sql)
       @handler.close
     end
@@ -200,6 +204,19 @@ DESC
           values << value
         end
         values
+      end
+    end
+
+    def transaction_isolation_level
+      case @transaction_isolation_level
+      when :read_uncommitted
+        "READ UNCOMMITTED"
+      when :read_committed
+        "READ COMMITTED"
+      when :repeatable_read
+        "REPEATABLE READ"
+      when :serializable
+        "SERIALIZABLE"
       end
     end
   end

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -51,7 +51,7 @@ DESC
     config_param :on_duplicate_update_custom_values, :string, default: nil,
                  desc: "On_duplicate_update_custom_values, comma separator. specify the column name is insert value, custom value is use ${sql conditions}"
 
-    config_param :transaction_isolation_level, :enum, list: [:read_uncommitted, :read_committed, :repeatable_read, :serializable], default: :repeatable_read,
+    config_param :transaction_isolation_level, :enum, list: [:read_uncommitted, :read_committed, :repeatable_read, :serializable], default: :nil,
                  desc: "Set transaction isolation level."
 
     attr_accessor :handler
@@ -173,7 +173,7 @@ DESC
       sql += @on_duplicate_key_update_sql if @on_duplicate_key_update
 
       log.info "bulk insert values size (table: #{table}) => #{values.size}"
-      @handler.query("SET SESSION TRANSACTION ISOLATION LEVEL #{transaction_isolation_level}")
+      @handler.query("SET SESSION TRANSACTION ISOLATION LEVEL #{transaction_isolation_level}") if @transaction_isolation_level
       @handler.xquery(sql)
       @handler.close
     end


### PR DESCRIPTION
because on "repeatable read" level, deadlock sometimes occurs by gap lock.