### PR TITLE
Pass chunk directly instead of chunk metadata

### DIFF
--- a/fluent-plugin-mysql.gemspec
+++ b/fluent-plugin-mysql.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_runtime_dependency "fluentd", ['>= 0.14.8', '< 2']
+  gem.add_runtime_dependency "fluentd", ['>= 0.14.22', '< 2']
   gem.add_runtime_dependency "mysql2-cs-bind"
   gem.add_runtime_dependency "jsonpath"
   gem.add_runtime_dependency "oj"

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -153,14 +153,14 @@ DESC
         )
     end
 
-    def expand_placeholders(metadata)
-      database = extract_placeholders(@database, metadata).gsub('.', '_')
-      table = extract_placeholders(@table, metadata).gsub('.', '_')
+    def expand_placeholders(chunk)
+      database = extract_placeholders(@database, chunk).gsub('.', '_')
+      table = extract_placeholders(@table, chunk).gsub('.', '_')
       return database, table
     end
 
     def write(chunk)
-      database, table = expand_placeholders(chunk.metadata)
+      database, table = expand_placeholders(chunk)
       max_lengths = check_table_schema(database: database, table: table)
       @handler = client(database)
       values = []


### PR DESCRIPTION
extract_placeholders should be passed chunk instance directly instead of chunk.metadata.