### PR TITLE
Added new feature to force empty values to nil

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ fluent plugin mysql bulk insert is high performance and on duplicate key update 
 
 ## Note
 fluent-plugin-mysql-bulk merged this repository.
-
+This repository now includes the mysql_bulk plugin.
 [mysql plugin](README_mysql.md) is deprecated. You should use mysql_bulk.
 
 v0.1.5 only supports fluentd-0.12.X and v0.2.0 only supports fluentd-0.14.X.
@@ -33,6 +33,7 @@ table|bulk insert table (require)
 on_duplicate_key_update|on duplicate key update enable (true:false)
 on_duplicate_update_keys|on duplicate key update column, comma separator
 transaction_isolation_level|set transaction isolation level(default: nil)
+column_names_empty_to_null|Columns for which empty values should be converted to nil (null in SQL)
 
 ## Configuration Example(bulk insert)
 

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -54,6 +54,9 @@ DESC
     config_param :transaction_isolation_level, :enum, list: [:read_uncommitted, :read_committed, :repeatable_read, :serializable], default: nil,
                  desc: "Set transaction isolation level."
 
+    config_param :column_names_empty_to_null, :string, default: nil,
+                 desc: "Columns for which empty values are stored as NULL (no quotes)"
+
     attr_accessor :handler
 
     def initialize
@@ -100,6 +103,7 @@ DESC
 
       @column_names = @column_names.split(',').collect(&:strip)
       @key_names = @key_names.nil? ? @column_names : @key_names.split(',').collect(&:strip)
+      @column_names_empty_to_null = @column_names_empty_to_null.split(',').collect(&:strip) if @column_names_empty_to_null
       @json_key_names = @json_key_names.split(',') if @json_key_names
       @unixtimestamp_key_names = @unixtimestamp_key_names.split(',') if @unixtimestamp_key_names
     end
@@ -199,6 +203,12 @@ DESC
 
             if @unixtimestamp_key_names && @unixtimestamp_key_names.include?(key)
               value = Time.at(value).strftime('%Y-%m-%d %H:%M:%S')
+            end
+
+            if @column_names_empty_to_null && @column_names_empty_to_null.include?(key)
+              if value.nil? || value.empty?
+                value = nil
+              end
             end
           end
           values << value


### PR DESCRIPTION
The new parameter column_names_empty_to_null is used to specify columns for which an empty parameter should be forced to nil (so it becomes a null when inserting to the DB).
This was essential for me where I had a CSV formatted log file I needed to push to various DB columns, but some of the CSV parameters could be "", for things like dates or int's resulting in errors during bulk insert.
With this version you just add those columns to column_names_empty_to_null and they are inserted as NULL to the table.
Perhaps a future improvement could be the possibility to have a mapping of input values to output values - for instance other inputs like - or * or ""  could all be considered null. This version I kept simple though.