### PR TITLE
Add try,catch statement for query

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -172,10 +172,16 @@ DESC
       sql = "INSERT INTO #{table} (#{@column_names.map{|x| "`#{x.to_s.gsub('`', '``')}`"}.join(',')}) VALUES #{values.join(',')}"
       sql += @on_duplicate_key_update_sql if @on_duplicate_key_update
 
-      log.info "bulk insert values size (table: #{table}) => #{values.size}"
-      @handler.query("SET SESSION TRANSACTION ISOLATION LEVEL #{transaction_isolation_level}") if @transaction_isolation_level
-      @handler.xquery(sql)
-      @handler.close
+      begin
+        log.info "bulk insert values size (table: #{table}) => #{values.size}"
+        @handler.query("SET SESSION TRANSACTION ISOLATION LEVEL #{transaction_isolation_level}") if @transaction_isolation_level
+        @handler.xquery(sql)
+      rescue Exception
+        log.warn "an unexpected error occurred while query"
+      ensure
+        @handler.close
+      end
+
     end
 
     private


### PR DESCRIPTION
Add try, catch statements.


I am using fluent-plugin-mysql plygun to save log to MySQL periodically every minute.

However, after Mysql2 error, the data received from source can't save to MySQL. Keep trying retry.

Even though Mysql2 error occurs after adding try, catch statements, data received from source can save to MySQL.


**Before**

```
2020-02-14 10:15:53 +0900 [info]: #0 bulk insert values size (table: searchzum_component_click_test) => 1
...
2020-02-14 10:07:55 +0900 [warn]: #0 failed to flush the buffer. retry_time=1 next_retry_seconds=2020-02-14 10:07:56 +0900 chunk="59e7ed53eb5cc4525fdaeeb7686061cd" error_class=Mysql2::Error error="Column 'date_time' cannot be null"
  2020-02-14 10:07:55 +0900 [warn]: #0 suppressed same stacktrace
2020-02-14 10:07:56 +0900 [info]: #0 bulk insert values size (table: searchzum_component_click_test) => 1
2020-02-14 10:07:56 +0900 [warn]: #0 failed to flush the buffer. retry_time=2 next_retry_seconds=2020-02-14 10:07:58 +0900 chunk="59e7ed53eb5cc4525fdaeeb7686061cd" error_class=Mysql2::Error error="Column 'date_time' cannot be null"
  2020-02-14 10:07:56 +0900 [warn]: #0 suppressed same stacktrace
2020-02-14 10:07:58 +0900 [info]: #0 bulk insert values size (table: searchzum_component_click_test) => 1
```


**After**

```
2020-02-14 10:13:02 +0900 [info]: #0 fluentd worker is now running worker=0
2020-02-14 10:15:24 +0900 [info]: #0 bulk insert values size (table: searchzum_component_click_test) => 3645
2020-02-14 10:15:53 +0900 [info]: #0 bulk insert values size (table: searchzum_component_click_test) => 1
2020-02-14 10:15:53 +0900 [warn]: #0 an unexpected query error occurred
2020-02-14 10:16:21 +0900 [info]: #0 bulk insert values size (table: searchzum_component_click_test) => 3662
```

