### PR TITLE
Add init_command parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ sslca|path to ca cert(default: nil)
 sslcapath|path to ca certs(default: nil)
 sslcipher|ssl cipher(default: nil)
 sslverify|verify server certificate(default: nil)
+init_command|SQL string executed after the connection is established(default: nil)
 column_names|bulk insert column (require)
 key_names|value key names, ${time} is placeholder Time.at(time).strftime("%Y-%m-%d %H:%M:%S") (default : column_names)
 json_key_names|Key names which store data as json, comma separator.

--- a/lib/fluent/plugin/out_mysql.rb
+++ b/lib/fluent/plugin/out_mysql.rb
@@ -15,6 +15,7 @@ class Fluent::MysqlOutput < Fluent::BufferedOutput
   config_param :sslcapath, :string, :default => nil
   config_param :sslcipher, :string, :default => nil
   config_param :sslverify, :bool, :default => nil
+  config_param :init_command, :string, :default => nil
 
   config_param :key_names, :string, :default => nil # nil allowed for json format
   config_param :sql, :string, :default => nil
@@ -112,6 +113,7 @@ class Fluent::MysqlOutput < Fluent::BufferedOutput
         :sslcapath => @sslcapath,
         :sslcipher => @sslcipher,
         :sslverify => @sslverify,
+        :init_command => @init_command,
         :flags => Mysql2::Client::MULTI_STATEMENTS,
       })
   end

--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -29,6 +29,8 @@ module Fluent::Plugin
                          desc: "SSL cipher."
     config_param :sslverify, :bool, default: nil,
                              desc: "SSL Verify Server Certificate."
+    config_param :init_command, :string, default: nil,
+                 desc: "SQL string executed after the connection is established."
 
     config_param :column_names, :string,
                  desc: "Bulk insert column."
@@ -149,6 +151,7 @@ DESC
           sslcapath: @sslcapath,
           sslcipher: @sslcipher,
           sslverify: @sslverify,
+          init_command: @init_command,
           flags: Mysql2::Client::MULTI_STATEMENTS
         )
     end


### PR DESCRIPTION
This adds a config parameter `init_command`, which specifies a SQL string executed after the connection to the database is established.
This can be useful to set sql_mode, for example.
c.f. https://github.com/brianmario/mysql2#initial-command-on-connect-and-reconnect