### PR TITLE
fix can't insert utf8mb4 value

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -143,6 +143,7 @@ DESC
           username: @username,
           password: @password,
           database: database,
+          encoding: 'utf8mb4',
           sslkey: @sslkey,
           sslcert: @sslcert,
           sslca: @sslca,


### PR DESCRIPTION
for fix that can't insert utf8mb4 string value, like error_class=Mysql2::Error error="Incorrect string value: '\\xF0\\x9F\\x90\\xAF' for column xxx