### PR TITLE
Reuse MySQL connection across flushes; never swallow flush errors

### DIFF
--- a/lib/fluent/plugin/out_mysql_bulk.rb
+++ b/lib/fluent/plugin/out_mysql_bulk.rb
@@ -162,23 +162,53 @@ DESC
     def write(chunk)
       database, table = expand_placeholders(chunk)
       max_lengths = check_table_schema(database: database, table: table)
-      @handler = client(database)
-      values = []
-      values_template = "(#{ @column_names.map { |key| '?' }.join(',') })"
-      chunk.msgpack_each do |tag, time, data|
-        data = format_proc.call(tag, time, data, max_lengths)
-        values << Mysql2::Client.pseudo_bind(values_template, data)
+      # Reuse the connection across successful flushes instead of reconnecting
+      # every time. Open a new one only when there is no usable handler (the
+      # first flush, or the previous one was discarded by the error path below)
+      # or when the target database changed -- the INSERT uses an unqualified
+      # table name, so it must run on a connection bound to the right database.
+      if @handler.nil? || @handler_database != database
+        close_handler
+        @handler = client(database)
+        @handler_database = database
       end
-      sql = "INSERT INTO #{table} (#{@column_names.map{|x| "`#{x.to_s.gsub('`', '``')}`"}.join(',')}) VALUES #{values.join(',')}"
-      sql += @on_duplicate_key_update_sql if @on_duplicate_key_update
 
-      log.info "bulk insert values size (table: #{table}) => #{values.size}"
-      @handler.query("SET SESSION TRANSACTION ISOLATION LEVEL #{transaction_isolation_level}") if @transaction_isolation_level
-      @handler.xquery(sql)
-      @handler.close
+      begin
+        values = []
+        values_template = "(#{ @column_names.map { |key| '?' }.join(',') })"
+        chunk.msgpack_each do |tag, time, data|
+          data = format_proc.call(tag, time, data, max_lengths)
+          values << Mysql2::Client.pseudo_bind(values_template, data)
+        end
+        sql = "INSERT INTO #{table} (#{@column_names.map{|x| "`#{x.to_s.gsub('`', '``')}`"}.join(',')}) VALUES #{values.join(',')}"
+        sql += @on_duplicate_key_update_sql if @on_duplicate_key_update
+
+        log.info "bulk insert values size (table: #{table}) => #{values.size}"
+        @handler.query("SET SESSION TRANSACTION ISOLATION LEVEL #{transaction_isolation_level}") if @transaction_isolation_level
+        @handler.xquery(sql)
+      rescue
+        # Drop the (possibly broken) connection so the next retry reconnects, and
+        # re-raise: the error MUST propagate so Fluentd retries the chunk instead
+        # of treating the flush as successful and silently dropping the buffered
+        # records. Swallowing it here would lose the whole bulk batch.
+        close_handler
+        raise
+      end
+    end
+
+    def close
+      super
+      close_handler
     end
 
     private
+
+    def close_handler
+      return if @handler.nil?
+      @handler.close rescue nil
+      @handler = nil
+      @handler_database = nil
+    end
 
     def format_proc
       proc do |tag, time, record, max_lengths|

--- a/test/plugin/test_out_mysql_bulk.rb
+++ b/test/plugin/test_out_mysql_bulk.rb
@@ -357,4 +357,87 @@ class MysqlBulkOutputTest < Test::Unit::TestCase
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.key_names
     assert_equal ['id','user_name','created_at','updated_at'], d.instance.column_names
   end
+
+  class TestWriteConnectionHandling < self
+    # A fake MySQL handler that records #close calls. By default queries succeed
+    # (SHOW COLUMNS, issued by check_table_schema, returns an empty result set);
+    # pass fail_insert: true to make the INSERT raise.
+    class RecordingHandler
+      attr_reader :close_count
+
+      def initialize(fail_insert: false)
+        @close_count = 0
+        @fail_insert = fail_insert
+      end
+
+      def query(*); end
+
+      def xquery(sql = nil, *)
+        return [] if sql.to_s.start_with?('SHOW COLUMNS')
+        raise 'INSERT failed' if @fail_insert
+        [1]
+      end
+
+      def close
+        @close_count += 1
+      end
+    end
+
+    def build_chunk(records, tag: 'test', time: Time.now.to_i)
+      rows = records.map { |record| [tag, time, record] }
+      # write/1 calls expand_placeholders(chunk) and then chunk.msgpack_each.
+      # extract_placeholders accepts a Metadata as its chunk argument (its
+      # documented "old plugin" path) and our database/table have no
+      # placeholders, so a Metadata extended with #msgpack_each is enough to
+      # drive write/1 without the full buffer-chunk machinery.
+      chunk = create_metadata
+      chunk.define_singleton_method(:msgpack_each) do |&block|
+        rows.each { |row| block.call(*row) }
+      end
+      chunk
+    end
+
+    def test_write_propagates_error_and_closes_handler_on_failure
+      d = create_driver
+      handlers = []
+      d.instance.define_singleton_method(:client) do |_database|
+        handler = RecordingHandler.new(fail_insert: true)
+        handlers << handler
+        handler
+      end
+
+      chunk = build_chunk([{ 'id' => 1, 'user_name' => 'alice', 'created_at' => '2016-09-26 12:00:00' }])
+
+      assert_raise(RuntimeError) do
+        d.instance.write(chunk)
+      end
+
+      # write/1 opens its own handler after check_table_schema; that handler must
+      # be closed (and dropped) when the INSERT raises, so the next retry
+      # reconnects instead of reusing a broken connection.
+      assert_equal(1, handlers.last.close_count)
+      assert_nil(d.instance.handler)
+    end
+
+    def test_write_reuses_handler_across_successful_writes_and_closes_on_shutdown
+      d = create_driver
+      d.instance.define_singleton_method(:client) do |_database|
+        RecordingHandler.new
+      end
+
+      d.instance.write(build_chunk([{ 'id' => 1, 'user_name' => 'alice', 'created_at' => '2016-09-26 12:00:00' }]))
+      reused = d.instance.handler
+      d.instance.write(build_chunk([{ 'id' => 2, 'user_name' => 'bob', 'created_at' => '2016-09-26 12:00:00' }]))
+
+      # The INSERT handler is opened once and kept open: the second successful
+      # flush must reuse the same connection rather than reconnecting.
+      assert_same(reused, d.instance.handler)
+      assert_equal(0, reused.close_count)
+
+      # The held connection is released when the plugin shuts down.
+      d.instance.close
+      assert_equal(1, reused.close_count)
+      assert_nil(d.instance.handler)
+    end
+  end
 end

--- a/test/plugin/test_out_mysql_bulk_integration.rb
+++ b/test/plugin/test_out_mysql_bulk_integration.rb
@@ -3,6 +3,7 @@ require 'helper'
 require 'mysql2-cs-bind'
 require 'fluent/test/driver/output'
 require 'fluent/test/helpers'
+require 'fluent/plugin/buffer'
 require 'fluent/config'
 require 'time'
 
@@ -75,6 +76,22 @@ class MysqlBulkOutputIntegrationTest < Test::Unit::TestCase
     @client.query("SELECT * FROM `#{TABLE}` ORDER BY id").to_a
   end
 
+  # Builds a minimal buffer-chunk-like object so a single write/1 call can be
+  # exercised directly. Driving the error path through d.run is unreliable here
+  # because flush happens on a background thread that swallows the exception, so
+  # we call write/1 ourselves to observe how it handles a failing INSERT.
+  # extract_placeholders accepts a Metadata as its chunk argument (the "old
+  # plugin" path) and our database/table have no placeholders, so a Metadata
+  # extended with #msgpack_each is enough to drive write/1.
+  def build_chunk(records, tag: 'test', time: event_time("2016-09-26 12:00:00 UTC"))
+    rows = records.map { |record| [tag, time, record] }
+    chunk = Fluent::Plugin::Buffer::Metadata.new(nil, nil, nil)
+    chunk.define_singleton_method(:msgpack_each) do |&block|
+      rows.each { |row| block.call(*row) }
+    end
+    chunk
+  end
+
   def test_bulk_insert
     conf = base_config(%[
       column_names id,user_name,created_at
@@ -108,6 +125,47 @@ class MysqlBulkOutputIntegrationTest < Test::Unit::TestCase
     rows = select_all
     assert_equal(1, rows.size)
     assert_equal(50, rows[0]["user_name"].length)
+  end
+
+  # Regression test for the swallow-the-error approach proposed in
+  # https://github.com/tagomoris/fluent-plugin-mysql/pull/65 : a failing INSERT
+  # (here a NOT NULL violation, the exact error reported in that PR) must raise
+  # out of write/1 so Fluentd retries the chunk. If the error were rescued and
+  # swallowed, Fluentd would treat the flush as successful and silently drop
+  # every record in the chunk.
+  def test_failed_insert_raises_so_chunk_is_not_silently_dropped
+    conf = base_config(%[
+      column_names id,user_name
+      key_names id,user_name
+    ])
+    d = create_driver(conf)
+    chunk = build_chunk([{ "id" => nil, "user_name" => "alice" }]) # id is NOT NULL
+
+    assert_raise(Mysql2::Error) do
+      d.instance.write(chunk)
+    end
+
+    assert_equal(0, select_all.size)
+  end
+
+  # A successful flush keeps its MySQL connection open so the next flush reuses
+  # it instead of reconnecting every time.
+  def test_connection_is_reused_across_successful_writes
+    conf = base_config(%[
+      column_names id,user_name
+      key_names id,user_name
+    ])
+    d = create_driver(conf)
+    begin
+      d.instance.write(build_chunk([{ "id" => 1, "user_name" => "alice" }]))
+      first = d.instance.handler
+      d.instance.write(build_chunk([{ "id" => 2, "user_name" => "bob" }]))
+
+      assert_same(first, d.instance.handler)
+      assert_equal(2, select_all.size)
+    ensure
+      d.instance.close
+    end
   end
 
   def test_on_duplicate_key_update_with_custom_value


### PR DESCRIPTION
## Summary

`out_mysql_bulk`'s `write/1` opened a fresh MySQL connection on **every** flush and closed it only on the success path. Two problems:

1. A failing `INSERT` (e.g. a `NOT NULL` violation on bad input) skipped the close and **leaked the connection on every Fluentd retry**.
2. Even on success, reconnecting per flush is wasteful.

This PR makes the connection **persist and be reused across successful flushes**, while keeping errors propagating correctly.

## Behavior

- **Success:** keep the connection open and reuse it on the next flush.
- **Reconnect** only when there is no usable handler (first flush, or it was discarded by the error path) or when the **target database changed** — the `INSERT` uses an unqualified table name, so it must run on a connection bound to the right database (placeholder-driven `database` can vary per chunk).
- **Error:** drop the (possibly broken) connection so the next retry reconnects — this also recovers from a server-side *"MySQL server has gone away"* — then **re-raise**.
- **Shutdown:** release the held connection via `#close`.

## Why not swallow the error (re: #65)

#65 proposes `rescue Exception` + `log.warn` to stop the endless retries the author saw. That removes the symptom but introduces a worse one:

- Fluentd's buffered output decides success/failure by **whether `write/1` raises**. Swallowing makes Fluentd treat the flush as **successful** and **purge the chunk** → every buffered record is **silently dropped**. Because this is a *bulk* insert, one bad row fails the whole statement, so the **entire batch** (potentially thousands of good rows) is lost.
- `rescue Exception` (vs `StandardError`) also swallows `Interrupt`/`SignalException`, and the proposed log line drops the exception class/message.

Operators who want to cap retries on permanently-bad data should use Fluentd's own `retry_max_times` / `<secondary>`, which this change leaves working.

## Known limitation (pre-existing)

As before, `write/1` uses a single `@handler` instance variable and is **not safe for `flush_thread_count > 1`**. This PR does not change that; thread-local/pooled connections would be a separate, larger change.

## Tests

- **unit** (`test_out_mysql_bulk.rb`, no live MySQL): a stubbed handler proves `write/1` reuses one connection across successful flushes and closes it on shutdown, and that a failing `INSERT` re-raises while closing **and dropping** the connection.
- **integration** (`test_out_mysql_bulk_integration.rb`): a `NOT NULL` violation (the exact error from #65) must raise out of `write/1` and insert nothing; a second successful flush reuses the same connection object.

Supersedes #65.